### PR TITLE
Add CRUD for global models

### DIFF
--- a/CardShowcaseAPI/Configuration/MongoDbSettings.cs
+++ b/CardShowcaseAPI/Configuration/MongoDbSettings.cs
@@ -19,4 +19,9 @@ public class MongoDbSettings
     /// Имя коллекции для карточек
     /// </summary>
     public string CollectionName { get; set; } = "ShowcaseCards";
+
+    /// <summary>
+    /// Имя коллекции для глобальных моделей
+    /// </summary>
+    public string GlobalModelCollectionName { get; set; } = "GlobalModels";
 }

--- a/CardShowcaseAPI/Controllers/GlobalModelController.cs
+++ b/CardShowcaseAPI/Controllers/GlobalModelController.cs
@@ -1,0 +1,47 @@
+using CardShowcaseAPI.Models.Domain;
+using CardShowcaseAPI.Models.DTOs;
+using CardShowcaseAPI.Models.Enums;
+using CardShowcaseAPI.Services.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CardShowcaseAPI.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class GlobalModelController : ControllerBase
+{
+    private readonly IGlobalModelService _service;
+    private readonly ILogger<GlobalModelController> _logger;
+
+    public GlobalModelController(IGlobalModelService service, ILogger<GlobalModelController> logger)
+    {
+        _service = service;
+        _logger = logger;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<GlobalModel>>> GetAll() =>
+        Ok(await _service.GetAllAsync());
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<GlobalModel?>> GetById(Guid id) =>
+        await _service.GetByIdAsync(id) is GlobalModel model ? Ok(model) : NotFound();
+
+    [HttpGet("user/{userId:guid}")]
+    public async Task<ActionResult<List<GlobalModel>>> GetByUser(Guid userId) =>
+        Ok(await _service.GetByUserAsync(userId));
+
+    [HttpPost]
+    public async Task<ActionResult<GlobalModel?>> Process([FromBody] GlobalModelModifyModel model)
+    {
+        var result = await _service.ProcessAsync(model);
+        return result switch
+        {
+            null when model.Action == GlobalModelAction.Delete => NoContent(),
+            null => BadRequest(),
+            _ => Ok(result)
+        };
+    }
+}

--- a/CardShowcaseAPI/Extensions/ServiceCollectionExtensions.cs
+++ b/CardShowcaseAPI/Extensions/ServiceCollectionExtensions.cs
@@ -21,6 +21,8 @@ namespace CardShowcaseAPI.Extensions
             services.Configure<JwtValidationSettings>(configuration.GetSection("JwtValidation"));
             // Сервис работы с карточками
             services.AddScoped<IShowcaseCardService, ShowcaseCardService>();
+            // Сервис работы с глобальными моделями
+            services.AddScoped<IGlobalModelService, GlobalModelService>();
             return services;
         }
 

--- a/CardShowcaseAPI/Models/DTOs/GlobalModelModifyModel.cs
+++ b/CardShowcaseAPI/Models/DTOs/GlobalModelModifyModel.cs
@@ -1,0 +1,35 @@
+using CardShowcaseAPI.Models.Domain;
+using CardShowcaseAPI.Models.Enums;
+
+namespace CardShowcaseAPI.Models.DTOs;
+
+/// <summary>
+/// Модель для создания/изменения глобальной модели
+/// </summary>
+public class GlobalModelModifyModel
+{
+    /// <summary>
+    /// Тип операции над моделью
+    /// </summary>
+    public GlobalModelAction Action { get; set; }
+
+    /// <summary>
+    /// ID модели (для обновления/удаления)
+    /// </summary>
+    public Guid? IDGlobalModel { get; set; }
+
+    /// <summary>
+    /// Название глобальной модели
+    /// </summary>
+    public string Name { get; set; } = null!;
+
+    /// <summary>
+    /// Конфигурация полей модели
+    /// </summary>
+    public List<GlobalModelField> Fields { get; set; } = new();
+
+    /// <summary>
+    /// ID создателя модели
+    /// </summary>
+    public Guid IDUserCreator { get; set; }
+}

--- a/CardShowcaseAPI/Models/Domain/GlobalModel.cs
+++ b/CardShowcaseAPI/Models/Domain/GlobalModel.cs
@@ -1,0 +1,146 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using CardShowcaseAPI.Models.Enums;
+
+namespace CardShowcaseAPI.Models.Domain;
+
+/// <summary>
+/// Глобальная модель для хранения конфигурации
+/// </summary>
+public class GlobalModel
+{
+    /// <summary>
+    /// Уникальный идентификатор глобальной модели
+    /// </summary>
+    [BsonId]
+    [BsonRepresentation(BsonType.String)]
+    public Guid IDGlobalModel { get; set; }
+
+    /// <summary>
+    /// Название глобальной модели
+    /// </summary>
+    [BsonElement("Name")]
+    public string Name { get; set; } = null!;
+
+    /// <summary>
+    /// Конфигурация полей модели
+    /// </summary>
+    [BsonElement("Fields")]
+    public List<GlobalModelField> Fields { get; set; } = new();
+
+    /// <summary>
+    /// ID пользователя, создавшего модель
+    /// </summary>
+    [BsonElement("IDUserCreator")]
+    [BsonRepresentation(BsonType.String)]
+    public Guid IDUserCreator { get; set; }
+
+    /// <summary>
+    /// Дата создания
+    /// </summary>
+    [BsonElement("CreatedAt")]
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// Дата последнего обновления
+    /// </summary>
+    [BsonElement("UpdatedAt")]
+    public DateTime UpdatedAt { get; set; }
+}
+
+/// <summary>
+/// Описание поля глобальной модели
+/// </summary>
+public class GlobalModelField
+{
+    /// <summary>
+    /// Имя поля модели
+    /// </summary>
+    [BsonElement("FieldName")]
+    public string FieldName { get; set; } = null!;
+
+    /// <summary>
+    /// Тип источника данных поля
+    /// </summary>
+    [BsonElement("SourceType")]
+    [BsonRepresentation(BsonType.String)]
+    public GlobalModelSourceType SourceType { get; set; }
+
+    /// <summary>
+    /// Источник данных Web API
+    /// </summary>
+    [BsonElement("FieldSource")]
+    public WebApiSource? FieldSource { get; set; }
+
+    /// <summary>
+    /// Источник данных датаблока
+    /// </summary>
+    [BsonElement("DatablockSource")]
+    public string? DatablockSource { get; set; }
+}
+
+/// <summary>
+/// Информация о методе Web API
+/// </summary>
+public class WebApiSource
+{
+    /// <summary>
+    /// Идентификатор конфигурации источника
+    /// </summary>
+    [BsonElement("Id")]
+    public string Id { get; set; } = null!;
+
+    /// <summary>
+    /// Идентификатор объекта Web API
+    /// </summary>
+    [BsonElement("WebApiId")]
+    public object? WebApiId { get; set; }
+
+    /// <summary>
+    /// Название метода
+    /// </summary>
+    [BsonElement("MethodId")]
+    public string MethodId { get; set; } = null!;
+
+    /// <summary>
+    /// Флаг интеграции
+    /// </summary>
+    [BsonElement("Integration")]
+    public bool Integration { get; set; }
+
+    /// <summary>
+    /// Параметры запроса
+    /// </summary>
+    [BsonElement("Params")]
+    public List<MethodParam> Params { get; set; } = new();
+
+    /// <summary>
+    /// Параметры запроса в виде JSON
+    /// </summary>
+    [BsonElement("JsonParams")]
+    public string JsonParams { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Использовать ли JsonParams
+    /// </summary>
+    [BsonElement("UseJsonParams")]
+    public bool UseJsonParams { get; set; }
+}
+
+/// <summary>
+/// Параметр запроса
+/// </summary>
+public class MethodParam
+{
+    /// <summary>
+    /// Имя параметра
+    /// </summary>
+    [BsonElement("Name")]
+    public string Name { get; set; } = null!;
+
+    /// <summary>
+    /// Значение параметра
+    /// </summary>
+    [BsonElement("Value")]
+    public object? Value { get; set; }
+}

--- a/CardShowcaseAPI/Models/Enums/GlobalModelAction.cs
+++ b/CardShowcaseAPI/Models/Enums/GlobalModelAction.cs
@@ -1,0 +1,22 @@
+namespace CardShowcaseAPI.Models.Enums;
+
+/// <summary>
+/// Действие над глобальной моделью
+/// </summary>
+public enum GlobalModelAction
+{
+    /// <summary>
+    /// Создание модели
+    /// </summary>
+    Create = 0,
+
+    /// <summary>
+    /// Обновление модели
+    /// </summary>
+    Update = 1,
+
+    /// <summary>
+    /// Удаление модели
+    /// </summary>
+    Delete = 2
+}

--- a/CardShowcaseAPI/Models/Enums/GlobalModelSourceType.cs
+++ b/CardShowcaseAPI/Models/Enums/GlobalModelSourceType.cs
@@ -1,0 +1,17 @@
+namespace CardShowcaseAPI.Models.Enums;
+
+/// <summary>
+/// Тип источника данных для поля глобальной модели
+/// </summary>
+public enum GlobalModelSourceType
+{
+    /// <summary>
+    /// Данные получаются из Web API
+    /// </summary>
+    WebApi = 0,
+
+    /// <summary>
+    /// Данные получаются из датаблока
+    /// </summary>
+    Datablock = 1
+}

--- a/CardShowcaseAPI/Services/Implementations/GlobalModelService.cs
+++ b/CardShowcaseAPI/Services/Implementations/GlobalModelService.cs
@@ -1,0 +1,236 @@
+using CardShowcaseAPI.Configuration;
+using CardShowcaseAPI.Models.Domain;
+using CardShowcaseAPI.Models.DTOs;
+using CardShowcaseAPI.Models.Enums;
+using CardShowcaseAPI.Services.Interfaces;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+
+namespace CardShowcaseAPI.Services.Implementations;
+
+/// <summary>
+/// Сервис для работы с глобальными моделями в MongoDB
+/// </summary>
+public class GlobalModelService : IGlobalModelService
+{
+    private readonly IMongoCollection<GlobalModel> _modelsCollection;
+    private readonly ILogger<GlobalModelService> _logger;
+
+    public GlobalModelService(
+        IOptions<MongoDbSettings> mongoDbSettings,
+        ILogger<GlobalModelService> logger)
+    {
+        _logger = logger;
+
+        try
+        {
+            var mongoClient = new MongoClient(mongoDbSettings.Value.ConnectionString);
+            var mongoDatabase = mongoClient.GetDatabase(mongoDbSettings.Value.DatabaseName);
+            _modelsCollection = mongoDatabase.GetCollection<GlobalModel>(mongoDbSettings.Value.GlobalModelCollectionName);
+            CreateIndexes();
+            _logger.LogInformation("Успешное подключение к MongoDB: {Database}", mongoDbSettings.Value.DatabaseName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Ошибка подключения к MongoDB");
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Создание индексов для оптимизации запросов
+    /// </summary>
+    private void CreateIndexes()
+    {
+        try
+        {
+            var indexKeys = Builders<GlobalModel>.IndexKeys;
+            var indexes = new List<CreateIndexModel<GlobalModel>>
+            {
+                new(indexKeys.Ascending(x => x.IDUserCreator)),
+                new(indexKeys.Ascending(x => x.Name)),
+                new(indexKeys.Descending(x => x.CreatedAt))
+            };
+            _modelsCollection.Indexes.CreateMany(indexes);
+            _logger.LogInformation("Индексы MongoDB для глобальных моделей успешно созданы");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Не удалось создать индексы MongoDB для глобальных моделей");
+        }
+    }
+
+    public async Task<List<GlobalModel>> GetAllAsync()
+    {
+        try
+        {
+            return await _modelsCollection.Find(_ => true)
+                .SortByDescending(x => x.CreatedAt)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Ошибка при получении всех глобальных моделей");
+            throw;
+        }
+    }
+
+    public async Task<GlobalModel?> GetByIdAsync(Guid id)
+    {
+        try
+        {
+            return await _modelsCollection.Find(x => x.IDGlobalModel == id)
+                .FirstOrDefaultAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Ошибка при получении глобальной модели: {ModelId}", id);
+            throw;
+        }
+    }
+
+    public async Task<List<GlobalModel>> GetByUserAsync(Guid userId)
+    {
+        try
+        {
+            return await _modelsCollection.Find(x => x.IDUserCreator == userId)
+                .SortByDescending(x => x.CreatedAt)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Ошибка при получении глобальных моделей пользователя: {UserId}", userId);
+            throw;
+        }
+    }
+
+    public async Task<GlobalModel> CreateAsync(GlobalModelModifyModel model)
+    {
+        try
+        {
+            var entity = new GlobalModel
+            {
+                IDGlobalModel = Guid.NewGuid(),
+                Name = model.Name,
+                Fields = model.Fields,
+                IDUserCreator = model.IDUserCreator,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+
+            await _modelsCollection.InsertOneAsync(entity);
+            _logger.LogInformation("Создана глобальная модель {ModelId}", entity.IDGlobalModel);
+            return entity;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Ошибка при создании глобальной модели");
+            throw;
+        }
+    }
+
+    public async Task<GlobalModel?> UpdateAsync(GlobalModelModifyModel model)
+    {
+        try
+        {
+            if (!model.IDGlobalModel.HasValue)
+            {
+                _logger.LogWarning("Попытка обновления глобальной модели без ID");
+                return null;
+            }
+
+            var filter = Builders<GlobalModel>.Filter.Eq(x => x.IDGlobalModel, model.IDGlobalModel.Value);
+            var update = Builders<GlobalModel>.Update
+                .Set(x => x.Name, model.Name)
+                .Set(x => x.Fields, model.Fields)
+                .Set(x => x.UpdatedAt, DateTime.UtcNow);
+
+            var options = new FindOneAndUpdateOptions<GlobalModel>
+            {
+                ReturnDocument = ReturnDocument.After
+            };
+
+            var result = await _modelsCollection.FindOneAndUpdateAsync(filter, update, options);
+
+            if (result != null)
+            {
+                _logger.LogInformation("Обновлена глобальная модель {ModelId}", model.IDGlobalModel);
+            }
+            else
+            {
+                _logger.LogWarning("Глобальная модель {ModelId} не найдена для обновления", model.IDGlobalModel);
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Ошибка при обновлении глобальной модели: {ModelId}", model.IDGlobalModel);
+            throw;
+        }
+    }
+
+    public async Task<bool> DeleteAsync(Guid id)
+    {
+        try
+        {
+            var result = await _modelsCollection.DeleteOneAsync(x => x.IDGlobalModel == id);
+            if (result.DeletedCount > 0)
+            {
+                _logger.LogInformation("Удалена глобальная модель {ModelId}", id);
+                return true;
+            }
+            _logger.LogWarning("Глобальная модель {ModelId} не найдена для удаления", id);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Ошибка при удалении глобальной модели: {ModelId}", id);
+            throw;
+        }
+    }
+
+    public async Task<GlobalModel?> ProcessAsync(GlobalModelModifyModel model)
+    {
+        try
+        {
+            _logger.LogInformation("Обработка глобальной модели с действием: {Action}", model.Action);
+            switch (model.Action)
+            {
+                case GlobalModelAction.Create:
+                    return await CreateAsync(model);
+
+                case GlobalModelAction.Update:
+                {
+                    var updated = await UpdateAsync(model);
+                    if (updated != null)
+                    {
+                        return updated;
+                    }
+
+                    _logger.LogInformation("Обновление модели {ModelId} не нашло записи — выполняем создание новой", model.IDGlobalModel);
+                    model.IDGlobalModel = null;
+                    return await CreateAsync(model);
+                }
+
+                case GlobalModelAction.Delete:
+                    if (model.IDGlobalModel.HasValue)
+                    {
+                        var success = await DeleteAsync(model.IDGlobalModel.Value);
+                        return success ? new GlobalModel { IDGlobalModel = model.IDGlobalModel.Value } : null;
+                    }
+                    _logger.LogWarning("Попытка удаления глобальной модели без указания ID");
+                    return null;
+
+                default:
+                    _logger.LogWarning("Неизвестное действие: {Action}", model.Action);
+                    return null;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Ошибка при обработке глобальной модели с действием: {Action}", model.Action);
+            throw;
+        }
+    }
+}

--- a/CardShowcaseAPI/Services/Implementations/GlobalModelService.cs
+++ b/CardShowcaseAPI/Services/Implementations/GlobalModelService.cs
@@ -198,6 +198,8 @@ public class GlobalModelService : IGlobalModelService
             switch (model.Action)
             {
                 case GlobalModelAction.Create:
+                    // При создании игнорируем переданный ID и генерируем новый
+                    model.IDGlobalModel = null;
                     return await CreateAsync(model);
 
                 case GlobalModelAction.Update:

--- a/CardShowcaseAPI/Services/Interfaces/IGlobalModelService.cs
+++ b/CardShowcaseAPI/Services/Interfaces/IGlobalModelService.cs
@@ -1,0 +1,45 @@
+using CardShowcaseAPI.Models.Domain;
+using CardShowcaseAPI.Models.DTOs;
+
+namespace CardShowcaseAPI.Services.Interfaces;
+
+/// <summary>
+/// Интерфейс сервиса для работы с глобальными моделями
+/// </summary>
+public interface IGlobalModelService
+{
+    /// <summary>
+    /// Получить все модели
+    /// </summary>
+    Task<List<GlobalModel>> GetAllAsync();
+
+    /// <summary>
+    /// Получить модель по ID
+    /// </summary>
+    Task<GlobalModel?> GetByIdAsync(Guid id);
+
+    /// <summary>
+    /// Получить модели пользователя
+    /// </summary>
+    Task<List<GlobalModel>> GetByUserAsync(Guid userId);
+
+    /// <summary>
+    /// Создать новую модель
+    /// </summary>
+    Task<GlobalModel> CreateAsync(GlobalModelModifyModel model);
+
+    /// <summary>
+    /// Обновить модель
+    /// </summary>
+    Task<GlobalModel?> UpdateAsync(GlobalModelModifyModel model);
+
+    /// <summary>
+    /// Удалить модель
+    /// </summary>
+    Task<bool> DeleteAsync(Guid id);
+
+    /// <summary>
+    /// Обработать модель в зависимости от действия
+    /// </summary>
+    Task<GlobalModel?> ProcessAsync(GlobalModelModifyModel model);
+}

--- a/CardShowcaseAPI/appsettings.Development.json
+++ b/CardShowcaseAPI/appsettings.Development.json
@@ -9,7 +9,8 @@
   "MongoDB": {
     "ConnectionString": "mongodb://admin:Admin123!@localhost:27017",
     "DatabaseName": "ShowcaseCardDB",
-    "CollectionName": "ShowcaseCards"
+    "CollectionName": "ShowcaseCards",
+    "GlobalModelCollectionName": "GlobalModels"
   },
   "Jwt": {
     "Secret": "744773C6-3248-436B-89B3-AC26D986246A",


### PR DESCRIPTION
## Summary
- add global model domain, DTO, enums and service for CRUD operations stored in MongoDB
- expose GlobalModelController and register service
- add user/model GUID properties and configuration for new MongoDB collection

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894d3c561608332b624913ab062c25e